### PR TITLE
Use sync.pool for length buffer allocation and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ Status](https://travis-ci.org/nknorg/encrypted-stream.svg?branch=master)](https:
 Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
 
 Encrypted-stream is a Golang library that transforms any `net.Conn` or
-`io.ReadWriter` stream to an encrypted stream with any encrypt/decrypt function.
-The encrypted stream implements `net.Conn` and `io.ReadWriter` and can be used
-transparently.
+`io.ReadWriter` stream to an encrypted stream with any provided encrypt/decrypt
+function.
+
+- Works with any encryption/authentication algorithm or even general
+  transformation. Only a pair of encrypt/decrypt function needs to be provided.
+
+- The encrypted stream implements `net.Conn` and `io.ReadWriter` and can be used
+  transparently.
+
+- An encrypted stream only adds a small constant memory overhead compared to the
+  original stream.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ $ go test -v -bench=.
 goos: darwin
 goarch: amd64
 pkg: github.com/nknorg/encrypted-stream
-BenchmarkPipe-12    	    4609	    257154 ns/op	 509.70 MB/s	     121 B/op	       9 allocs/op
-BenchmarkTCP-12     	    5797	    248237 ns/op	 528.01 MB/s	     120 B/op	       9 allocs/op
+BenchmarkPipe-12    	    3867	    260929 ns/op	 502.33 MB/s	     292 B/op	       9 allocs/op
+BenchmarkTCP-12     	    6603	    215170 ns/op	 609.16 MB/s	     288 B/op	       9 allocs/op
 PASS
-ok  	github.com/nknorg/encrypted-stream	3.703s
+ok  	github.com/nknorg/encrypted-stream	2.509s
 ```
 
 ## Contributing

--- a/config.go
+++ b/config.go
@@ -6,27 +6,21 @@ import (
 	"github.com/imdario/mergo"
 )
 
-// EncryptFunc encrypts a plaintext to ciphertext. Returns ciphertext slice
-// whose length should be equal to ciphertext length. Input buffer ciphertext
-// has enough size for encrypted plaintext, and their size satisfy:
-// `len(plaintext) <= config.MaxChunkSize` and `len(ciphertext) ==
-// config.MaxChunkSize + config.MaxOverheadSize`.
-type EncryptFunc func(ciphertext, plaintext []byte) ([]byte, error)
-
-// DecryptFunc decrypts a ciphertext to plaintext. Returns plaintext slice whose
-// length should be equal to plaintext length. Input buffer plaintext has enough
-// size for decrypted ciphertext, and their size satisfy: `len(plaintext) ==
-// config.MaxChunkSize` and `len(ciphertext) <= config.MaxChunkSize +
-// config.MaxOverheadSize`.
-type DecryptFunc func(plaintext, ciphertext []byte) ([]byte, error)
-
-// Config is the stream configuration.
+// Config is the configuration for encrypted stream.
 type Config struct {
-	// EncryptFunc for encrypting buffer.
-	EncryptFunc EncryptFunc
+	// EncryptFunc encrypts a plaintext to ciphertext. Returns ciphertext slice
+	// whose length should be equal to ciphertext length. Input buffer ciphertext
+	// has enough length for encrypted plaintext, and the length satisfy:
+	// 	len(plaintext) <= config.MaxChunkSize
+	// 	len(ciphertext) == config.MaxChunkSize + config.MaxOverheadSize
+	EncryptFunc func(ciphertext, plaintext []byte) ([]byte, error)
 
-	// DecryptFunc for decrypting buffer.
-	DecryptFunc DecryptFunc
+	// DecryptFunc decrypts a ciphertext to plaintext. Returns plaintext slice
+	// whose length should be equal to plaintext length. Input buffer plaintext
+	// has enough length for decrypted ciphertext, and the length satisfy:
+	//	len(plaintext) == config.MaxChunkSize
+	//	len(ciphertext) <= config.MaxChunkSize + config.MaxOverheadSize
+	DecryptFunc func(plaintext, ciphertext []byte) ([]byte, error)
 
 	// MaxOverheadSize is the max number of bytes overhead of ciphertext compared
 	// to plaintext. It is only used to determine internal buffer size, so

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,17 @@
+/*
+
+Package stream is a Golang library that transforms any `net.Conn` or
+`io.ReadWriter` stream to an encrypted stream with any provided encrypt/decrypt
+function.
+
+1. Works with any encryption/authentication algorithm or even general
+transformation. Only a pair of encrypt/decrypt function needs to be provided.
+
+2. The encrypted stream implements `net.Conn` and `io.ReadWriter` and can be
+used transparently.
+
+3. An encrypted stream only adds a small constant memory overhead compared to
+the original stream.
+
+*/
+package stream


### PR DESCRIPTION
* Use sync.pool for length buffer allocation
* Improved comments and documentations
* Change EncryptedStream lock to private field