### PR TITLE
Add sequential nonce and direction to prevent MITM attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Encrypted-stream is a Golang library that transforms any `net.Conn` or
 - The encrypted stream only adds a small constant memory overhead compared to
   the original stream.
 
+Note: this library does not handle handshake or key exchange. Handshake should
+be done separately before using this library to compute a shared key.
+
 ## Documentation
 
 Full documentation can be found at
@@ -38,13 +41,15 @@ Assume you have a `net.Conn` and you want to transform it into an encrypted
 conn, err := net.Dial("tcp", "host:port")
 ```
 
-You first need to have a shared key at both side of the connection, (e.g.
-derived from  key exchange algorithm, or pre-determined). Then all you
-need to do is to choose or implements a cipher:
+You first need to have a shared key at both side of the connection (e.g.
+derived from  key exchange algorithm). Then all you need to do is to choose or
+implements a cipher:
 
 ```go
 encryptedConn, err := stream.NewEncryptedStream(conn, &stream.Config{
   Cipher: stream.NewXSalsa20Poly1305Cipher(&key),
+  SequentialNonce: true, // only when key is unique for every stream
+  Initiator: true, // only on the dialer side
 })
 ```
 
@@ -61,14 +66,14 @@ $ go test -v -bench=. -run=^$
 goos: darwin
 goarch: amd64
 pkg: github.com/nknorg/encrypted-stream
-BenchmarkPipeXSalsa20Poly1305-12    	    4712	    254008 ns/op	 516.01 MB/s	       1 B/op	       0 allocs/op
-BenchmarkPipeAESGCM128-12           	   18675	     65688 ns/op	1995.38 MB/s	       0 B/op	       0 allocs/op
-BenchmarkPipeAESGCM256-12           	   16060	     74029 ns/op	1770.55 MB/s	       0 B/op	       0 allocs/op
-BenchmarkTCPXSalsa20Poly1305-12     	    6760	    263446 ns/op	 497.53 MB/s	       0 B/op	       0 allocs/op
-BenchmarkTCPAESGCM128-12            	   14780	     82979 ns/op	1579.57 MB/s	       0 B/op	       0 allocs/op
-BenchmarkTCPAESGCM256-12            	   13321	     92393 ns/op	1418.64 MB/s	       0 B/op	       0 allocs/op
+BenchmarkPipeXSalsa20Poly1305-12    	    4064	    266725 ns/op	 491.41 MB/s	       3 B/op	       0 allocs/op
+BenchmarkPipeAESGCM128-12           	   16195	     71669 ns/op	1828.86 MB/s	       0 B/op	       0 allocs/op
+BenchmarkPipeAESGCM256-12           	   14328	     83337 ns/op	1572.79 MB/s	       0 B/op	       0 allocs/op
+BenchmarkTCPXSalsa20Poly1305-12     	    6489	    185980 ns/op	 704.76 MB/s	       0 B/op	       0 allocs/op
+BenchmarkTCPAESGCM128-12            	   20089	     59684 ns/op	2196.08 MB/s	       0 B/op	       0 allocs/op
+BenchmarkTCPAESGCM256-12            	   17656	     67721 ns/op	1935.48 MB/s	       0 B/op	       0 allocs/op
 PASS
-ok  	github.com/nknorg/encrypted-stream	9.471s
+ok  	github.com/nknorg/encrypted-stream	9.997s
 ```
 
 ## Contributing

--- a/cipher.go
+++ b/cipher.go
@@ -3,7 +3,6 @@ package stream
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
 	"errors"
 	"fmt"
 
@@ -17,20 +16,22 @@ type Cipher interface {
 	// has enough length for encrypted plaintext, and the length satisfy:
 	// 	len(ciphertext) == MaxChunkSize + MaxOverheadSize
 	// 	len(plaintext) <= MaxChunkSize
-	Encrypt(ciphertext, plaintext []byte) ([]byte, error)
+	Encrypt(ciphertext, plaintext, nonce []byte) ([]byte, error)
 
 	// Decrypt decrypts a ciphertext to plaintext. Returns plaintext slice
 	// whose length should be equal to plaintext length. Input buffer plaintext
 	// has enough length for decrypted ciphertext, and the length satisfy:
 	//	len(plaintext) == MaxChunkSize
 	//	len(ciphertext) <= MaxChunkSize + MaxOverheadSize
-	Decrypt(plaintext, ciphertext []byte) ([]byte, error)
+	Decrypt(plaintext, ciphertext, nonce []byte) ([]byte, error)
 
 	// MaxOverhead is the max number of bytes overhead of ciphertext compared to
-	// plaintext. This should contain both encryption overhead and size of
-	// additional data in ciphertext like nonce. It is only used to determine
-	// internal buffer size, so overestimate is ok.
+	// plaintext. It is only used to determine internal buffer size, so
+	// overestimate is ok.
 	MaxOverhead() int
+
+	// NonceSize is the nonce size in bytes.
+	NonceSize() int
 }
 
 // XSalsa20Poly1305Cipher is an AEAD cipher that uses XSalsa20 and Poly1305 to
@@ -42,6 +43,7 @@ type XSalsa20Poly1305Cipher struct {
 }
 
 // NewXSalsa20Poly1305Cipher creates a XSalsa20Poly1305Cipher with a given key.
+// For best security, every stream should have a unique key.
 func NewXSalsa20Poly1305Cipher(key *[32]byte) *XSalsa20Poly1305Cipher {
 	return &XSalsa20Poly1305Cipher{
 		key: key,
@@ -49,30 +51,21 @@ func NewXSalsa20Poly1305Cipher(key *[32]byte) *XSalsa20Poly1305Cipher {
 }
 
 // Encrypt implements Cipher.
-func (c *XSalsa20Poly1305Cipher) Encrypt(ciphertext, plaintext []byte) ([]byte, error) {
-	_, err := rand.Read(ciphertext[:24])
-	if err != nil {
-		return nil, err
-	}
+func (c *XSalsa20Poly1305Cipher) Encrypt(ciphertext, plaintext, nonce []byte) ([]byte, error) {
+	var n [24]byte
+	copy(n[:], nonce[:24])
 
-	var nonce [24]byte
-	copy(nonce[:], ciphertext[:24])
+	encrypted := secretbox.Seal(ciphertext[:0], plaintext, &n, c.key)
 
-	encrypted := secretbox.Seal(ciphertext[24:24], plaintext, &nonce, c.key)
-
-	return ciphertext[:24+len(encrypted)], nil
+	return ciphertext[:len(encrypted)], nil
 }
 
 // Decrypt implements Cipher.
-func (c *XSalsa20Poly1305Cipher) Decrypt(plaintext, ciphertext []byte) ([]byte, error) {
-	if len(ciphertext) <= c.overhead() {
-		return nil, fmt.Errorf("invalid ciphertext size %d", len(ciphertext))
-	}
+func (c *XSalsa20Poly1305Cipher) Decrypt(plaintext, ciphertext, nonce []byte) ([]byte, error) {
+	var n [24]byte
+	copy(n[:], nonce[:24])
 
-	var nonce [24]byte
-	copy(nonce[:], ciphertext[:24])
-
-	plaintext, ok := secretbox.Open(plaintext[:0], ciphertext[24:], &nonce, c.key)
+	plaintext, ok := secretbox.Open(plaintext[:0], ciphertext, &n, c.key)
 	if !ok {
 		return nil, errors.New("decrypt failed")
 	}
@@ -82,12 +75,17 @@ func (c *XSalsa20Poly1305Cipher) Decrypt(plaintext, ciphertext []byte) ([]byte, 
 
 // overhead returns Cipher's overhead including nonce size.
 func (c *XSalsa20Poly1305Cipher) overhead() int {
-	return 24 + secretbox.Overhead
+	return secretbox.Overhead
 }
 
 // MaxOverhead implements Cipher.
 func (c *XSalsa20Poly1305Cipher) MaxOverhead() int {
 	return c.overhead()
+}
+
+// NonceSize implements Cipher.
+func (c *XSalsa20Poly1305Cipher) NonceSize() int {
+	return 24
 }
 
 // CryptoAEADCipher is a wrapper to crypto/cipher AEAD interface and implements
@@ -104,25 +102,14 @@ func NewCryptoAEADCipher(aead cipher.AEAD) *CryptoAEADCipher {
 }
 
 // Encrypt implements Cipher.
-func (c *CryptoAEADCipher) Encrypt(ciphertext, plaintext []byte) ([]byte, error) {
-	nonceSize := c.aead.NonceSize()
-	_, err := rand.Read(ciphertext[:nonceSize])
-	if err != nil {
-		return nil, err
-	}
-
-	encrypted := c.aead.Seal(ciphertext[nonceSize:nonceSize], ciphertext[:nonceSize], plaintext, nil)
-
-	return ciphertext[:nonceSize+len(encrypted)], nil
+func (c *CryptoAEADCipher) Encrypt(ciphertext, plaintext, nonce []byte) ([]byte, error) {
+	encrypted := c.aead.Seal(ciphertext[:0], nonce, plaintext, nil)
+	return ciphertext[:len(encrypted)], nil
 }
 
 // Decrypt implements Cipher.
-func (c *CryptoAEADCipher) Decrypt(plaintext, ciphertext []byte) ([]byte, error) {
-	if len(ciphertext) <= c.overhead() {
-		return nil, fmt.Errorf("invalid ciphertext size %d", len(ciphertext))
-	}
-
-	plaintext, err := c.aead.Open(plaintext[:0], ciphertext[:c.aead.NonceSize()], ciphertext[c.aead.NonceSize():], nil)
+func (c *CryptoAEADCipher) Decrypt(plaintext, ciphertext, nonce []byte) ([]byte, error) {
+	plaintext, err := c.aead.Open(plaintext[:0], nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt failed: %v", err)
 	}
@@ -132,7 +119,7 @@ func (c *CryptoAEADCipher) Decrypt(plaintext, ciphertext []byte) ([]byte, error)
 
 // overhead returns Cipher's overhead including nonce size.
 func (c *CryptoAEADCipher) overhead() int {
-	return c.aead.NonceSize() + c.aead.Overhead()
+	return c.aead.Overhead()
 }
 
 // MaxOverhead implements Cipher.
@@ -140,9 +127,14 @@ func (c *CryptoAEADCipher) MaxOverhead() int {
 	return c.overhead()
 }
 
+// NonceSize implements Cipher.
+func (c *CryptoAEADCipher) NonceSize() int {
+	return c.aead.NonceSize()
+}
+
 // NewAESGCMCipher creates a 128-bit (16 bytes key) or 256-bit (32 bytes key)
 // AES block cipher wrapped in Galois Counter Mode with the standard nonce
-// length.
+// length. For best security, every stream should have a unique key.
 func NewAESGCMCipher(key []byte) (*CryptoAEADCipher, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -15,6 +15,26 @@ type Config struct {
 	// underlying stream in a single chunk. If zero, default value (65535) will be
 	// used.
 	MaxChunkSize int
+
+	// Initiator indicates the direction of the stream (initiator or responder).
+	// Two sides of the stream should set this to different value (i.e. one stream
+	// initiator and one stream responder) unless DisableNonceVerification is
+	// true.
+	Initiator bool
+
+	// Use sequential nonce instead of random nonce to prevent replay, re-order
+	// and packet drop attack. For cipher with short nonce (e.g. AES-GCM),
+	// sequential nonce should be used to prevent nonce reuse if large amount of
+	// data is transmitted in the same stream. Both sides of the stream should set
+	// this to the same value unless DisableNonceVerification is true. IMPORTANT:
+	// Enable sequential nonce only when key is unique for every stream, otherwise
+	// key will be leaked.
+	SequentialNonce bool
+
+	// Disable nonce verification during decryption. Setting this to true will
+	// make the stream vulnerable to reflection, replay, re-order and packet drop
+	// attack. Do not set it to true unless you have a strong reason.
+	DisableNonceVerification bool
 }
 
 // DefaultConfig returns the default config.
@@ -32,6 +52,10 @@ func (config *Config) Verify() error {
 
 	if config.Cipher.MaxOverhead() < 0 {
 		return errors.New("Cipher.MaxOverhead() should not be less than 0")
+	}
+
+	if config.Cipher.NonceSize() < 0 {
+		return errors.New("Cipher.NonceSize() should not be less than 0")
 	}
 
 	if config.MaxChunkSize <= 0 {

--- a/doc.go
+++ b/doc.go
@@ -14,5 +14,8 @@ as reference cipher.
 3. The encrypted stream only adds a small constant memory overhead compared to
 the original stream.
 
+Note: this library does not handle handshake or key exchange. Handshake should
+be done separately before using this library to compute a shared key.
+
 */
 package stream

--- a/encoding.go
+++ b/encoding.go
@@ -1,11 +1,176 @@
 package stream
 
 import (
+	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 )
+
+var (
+	// ErrMaxNonce indicates the max allowed nonce is reach. If this happends, a
+	// new stream with different key should be created.
+	ErrMaxNonce = errors.New("max nonce reached")
+
+	// ErrWrongNonceInitiator indicates a nonce with the wrong party is received,
+	// i.e. initiator receives a nonce from initiator, or responder receives a
+	// nonce from responder. It is either a configuration error (e.g. both party
+	// set initiator to the same value), or a middle man is performing reflection
+	// attack.
+	ErrWrongNonceInitiator = errors.New("wrong nonce direction")
+
+	// ErrWrongNonceSequential indicates a nonce with the wrong value is received.
+	// It is either a configuration error (e.g. one side set sequentialNonce to
+	// true, the other side set to false), or a middle man is performing replay,
+	// re-order or packet drop attack.
+	ErrWrongNonceSequential = errors.New("wrong nonce value")
+)
+
+// Encoder provides encode function of a slice data.
+type Encoder struct {
+	cipher          Cipher
+	initiator       bool
+	sequentialNonce bool
+	nextNonce       []byte
+	maxNonce        []byte
+}
+
+// NewEncoder creates a Encoder with given cipher and config.
+func NewEncoder(cipher Cipher, initiator, sequentialNonce bool) (*Encoder, error) {
+	encoder := &Encoder{
+		cipher:          cipher,
+		initiator:       initiator,
+		sequentialNonce: sequentialNonce,
+		nextNonce:       initNonce(cipher.NonceSize(), initiator),
+		maxNonce:        maxNonce(cipher.NonceSize(), initiator),
+	}
+
+	return encoder, nil
+}
+
+// Encode encodes a plaintext to nonce + ciphertext. When sequential nonce is
+// true, Encode is not thread safe and should not be called concurrently.
+func (e *Encoder) Encode(ciphertext, plaintext []byte) ([]byte, error) {
+	nonceSize := e.cipher.NonceSize()
+
+	if e.sequentialNonce {
+		if bytes.Compare(e.nextNonce, e.maxNonce) >= 0 {
+			return nil, ErrMaxNonce
+		}
+		copy(ciphertext[:nonceSize], e.nextNonce)
+		incrementNonce(e.nextNonce)
+	} else {
+		_, err := rand.Read(ciphertext[:nonceSize])
+		if err != nil {
+			return nil, err
+		}
+
+		if e.initiator {
+			ciphertext[0] &= 127
+		} else {
+			ciphertext[0] |= 128
+		}
+	}
+
+	encrypted, err := e.cipher.Encrypt(ciphertext[nonceSize:], plaintext, ciphertext[:nonceSize])
+	if err != nil {
+		return nil, err
+	}
+
+	return ciphertext[:nonceSize+len(encrypted)], nil
+}
+
+// Decoder provides decode function of a slice data.
+type Decoder struct {
+	cipher                   Cipher
+	initiator                bool
+	sequentialNonce          bool
+	disableNonceVerification bool
+	nextNonce                []byte
+}
+
+// NewDecoder creates a Decoder with given cipher and config.
+func NewDecoder(cipher Cipher, initiator, sequentialNonce, disableNonceVerification bool) (*Decoder, error) {
+	decoder := &Decoder{
+		cipher:                   cipher,
+		initiator:                initiator,
+		sequentialNonce:          sequentialNonce,
+		disableNonceVerification: disableNonceVerification,
+		nextNonce:                initNonce(cipher.NonceSize(), !initiator),
+	}
+
+	return decoder, nil
+}
+
+// Decode decodes a nonce + ciphertext to plaintext. When sequential nonce is
+// true, Decode is not thread safe and should not be called concurrently.
+func (d *Decoder) Decode(plaintext, ciphertext []byte) ([]byte, error) {
+	nonceSize := d.cipher.NonceSize()
+	if len(ciphertext) <= nonceSize {
+		return nil, fmt.Errorf("invalid ciphertext size %d", len(ciphertext))
+	}
+
+	nonce := ciphertext[:nonceSize]
+	if !d.disableNonceVerification {
+		if d.initiator {
+			if nonce[0]>>7 != 1 {
+				return nil, ErrWrongNonceInitiator
+			}
+		} else {
+			if nonce[0]>>7 != 0 {
+				return nil, ErrWrongNonceInitiator
+			}
+		}
+
+		if d.sequentialNonce {
+			if !bytes.Equal(nonce, d.nextNonce) {
+				return nil, ErrWrongNonceSequential
+			}
+		}
+	}
+
+	plaintext, err := d.cipher.Decrypt(plaintext, ciphertext[nonceSize:], nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	if d.sequentialNonce {
+		incrementNonce(d.nextNonce)
+	}
+
+	return plaintext, nil
+}
+
+func initNonce(nonceSize int, initiator bool) []byte {
+	b := make([]byte, nonceSize)
+	if !initiator {
+		b[0] |= 128
+	}
+	return b
+}
+
+func maxNonce(nonceSize int, initiator bool) []byte {
+	b := make([]byte, nonceSize)
+	for i := 0; i < len(b); i++ {
+		b[i] = 255
+	}
+	if initiator {
+		b[0] &= 127
+	}
+	return b
+}
+
+func incrementNonce(b []byte) {
+	for i := len(b) - 1; i >= 0; i-- {
+		b[i]++
+		if b[i] > 0 {
+			break
+		}
+	}
+}
 
 func readVarBytes(reader io.Reader, b, lenBuf []byte) (int, error) {
 	if len(lenBuf) < 4 {

--- a/example_test.go
+++ b/example_test.go
@@ -14,10 +14,9 @@ func Example() {
 		panic(err)
 	}
 
-	// In this example we treat key as a prior knowledge. If you use public-key
-	// cryptography, you can to do key exchange here using the original stream
-	// (e.g. alice sends her public key to bob given that she already know bob's
-	// public key) before creating encrypted stream from it.
+	// In this example we treat key as a prior knowledge. In actual usage you can
+	// do handshake here using the original stream and compute shared key before
+	// creating encrypted stream from it.
 	var key [32]byte
 	_, err = rand.Read(key[:])
 	if err != nil {
@@ -25,7 +24,9 @@ func Example() {
 	}
 
 	config := &stream.Config{
-		Cipher: stream.NewXSalsa20Poly1305Cipher(&key),
+		Cipher:          stream.NewXSalsa20Poly1305Cipher(&key),
+		SequentialNonce: true, // only when key is unique for every stream
+		Initiator:       true, // only on the dialer side
 	}
 
 	// Create an encrypted stream from a conn.

--- a/stream_test.go
+++ b/stream_test.go
@@ -51,16 +51,19 @@ func createEncryptedStreamPair(alice, bob io.ReadWriter, cipherID int) (*Encrypt
 		return nil, nil, fmt.Errorf("unknown cipher %v", cipherID)
 	}
 
-	config := &Config{
-		Cipher: cipher,
-	}
-
-	aliceEncrypted, err := NewEncryptedStream(alice, config)
+	aliceEncrypted, err := NewEncryptedStream(alice, &Config{
+		Cipher:          cipher,
+		SequentialNonce: true,
+		Initiator:       true,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	bobEncrypted, err := NewEncryptedStream(bob, config)
+	bobEncrypted, err := NewEncryptedStream(bob, &Config{
+		Cipher:          cipher,
+		SequentialNonce: true,
+	})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
* Support sequential nonce to prevent replay, re-order and packet drop attack
* Add stream direction (initiator) to prevent reflection attack
* Compatibility with old version is achieved through DisableNonceVerification config